### PR TITLE
Add run all user function feature to simple runner

### DIFF
--- a/src/runner/simple_runner.cpp
+++ b/src/runner/simple_runner.cpp
@@ -4,26 +4,73 @@
 #include <util/timing.h>
 #include <util/func.h>
 #include <zygote/ZygoteRegistry.h>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
 
+int runFunction(std::string &user, std::string &function, int runCount);
 
 int main(int argc, char *argv[]) {
     util::initLogging();
     const std::shared_ptr<spdlog::logger> logger = util::getLogger();
 
     int runCount;
-    if (argc == 3) {
+    std::string user;
+    std::string function = {};
+    if (argc == 2) {
         runCount = 1;
     }
+    else if (argc == 3) {
+        try {
+            runCount = std::stoi(argv[2]);
+        } catch (std::invalid_argument&) {
+            function =  argv[2];
+            runCount = 1;
+        }
+    }
     else if (argc == 4) {
+        function = argv[2];
         runCount = std::stoi(argv[3]);
     }
     else {
-        logger->error("Usage: simple_runner <user> <func> [run_count]");
+        logger->error("Usage: simple_runner <user> [func] [run_count]");
         return 1;
     }
 
-    std::string user = argv[1];
-    std::string function = argv[2];
+    user = argv[1];
+
+    if (function.empty()) {
+        util::SystemConfig &conf = util::getSystemConfig();
+        logger->info("Running codegen for user {} on dir {} with {} runs", user, conf.functionDir, runCount);
+
+        boost::filesystem::path path(conf.functionDir);
+        path.append(user);
+
+        if (!boost::filesystem::is_directory(path)) {
+            logger->error("Expected {} to be a directory", path.string());
+            return 1;
+        }
+
+        for (boost::filesystem::directory_iterator iter(path), end; iter != end; iter++) {
+            boost::filesystem::directory_entry subPath(iter->path().string());
+            std::string functionName = subPath.path().filename().string();
+            int failed = runFunction(user, functionName, runCount);
+            if (failed) {
+                throw std::runtime_error(fmt::format("Function {}/{} returned non-zero exit code {}", user, function, failed));
+            }
+        }
+    } else {
+        int failed = runFunction(user, function, runCount);
+        if (failed) {
+            throw std::runtime_error(fmt::format("Function {}/{} returned non-zero exit code {}", user, function, failed));
+        }
+    }
+
+    return 0;
+}
+
+int runFunction(std::string &user, std::string &function, int runCount) {
+
+    const std::shared_ptr<spdlog::logger> logger = util::getLogger();
 
     // Set up function call
     message::Message m = util::messageFactory(user, function);
@@ -46,6 +93,8 @@ int main(int argc, char *argv[]) {
     // Create new module from zygote
     wasm::WasmModule module(zygote);
 
+    int res = 0;
+
     // Run repeated executions
     for (int i = 0; i < runCount; i++) {
         logger->info("Run {} - {}/{} ", i, user, function);
@@ -55,12 +104,15 @@ int main(int argc, char *argv[]) {
         PROF_END(execution)
 
         if (result != 0) {
-            throw std::runtime_error(fmt::format("Non-zero return code ({})", result));
+            logger->error("Non-zero return code ({})", result);
+            res = 0;
         }
 
         // Reset using zygote
         module = zygote;
+
+        logger->info("DONE Run {} - {}/{} ", i, user, function);
     }
 
-    return 0;
+    return res;
 }

--- a/src/runner/simple_runner.cpp
+++ b/src/runner/simple_runner.cpp
@@ -26,8 +26,8 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    function = argv[2];
     user = argv[1];
+    function = argv[2];
 
     std::vector<std::string> functions;
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -147,7 +147,7 @@ from tasks.toolchain import (
     download_sysroot,
     download_runtime_root,
     run_local_codegen,
-    codegen_for_user,
+    codegen_user,
 )
 from tasks.upload import (
     upload_all,
@@ -189,6 +189,10 @@ from tasks.genomics import (
 )
 from tasks.prk import (
     invoke_prk,
+)
+from tasks.runner import (
+    run,
+    run_user,
 )
 # Can only generate matrix data with things installed
 try:

--- a/tasks/compile.py
+++ b/tasks/compile.py
@@ -54,9 +54,8 @@ def compile(ctx, user, func, clean=False, debug=False, ts=False, cp=False):
         ]
         call(" ".join(cmd), shell=True, cwd=FUNC_BUILD_DIR)
 
-
 @task
-def compile_user(ctx, user, clean=False, debug=False, cp=False):
+def compile_user(ctx, user, clean=False, debug=False, cp=False, run=False):
     target = "{}_all_funcs".format(user)
     _do_compile(target, clean, debug)
     if cp:
@@ -79,6 +78,9 @@ def compile_user(ctx, user, clean=False, debug=False, cp=False):
                 join(dest_folder, "function.wasm"),
             ]
             call(" ".join(cmd), shell=True, cwd=FUNC_BUILD_DIR)
+        if run:
+            _codegen_user(user, debug)
+            _simple_run_user(user, debug)
 
 
 def _ts_compile(func, optimize=True):
@@ -99,3 +101,22 @@ def _ts_compile(func, optimize=True):
     cmd_string = " ".join(cmd)
     print(cmd_string)
     call(cmd_string, cwd=TS_DIR, shell=True)
+
+def _codegen_user(user, debug):
+    cmd = " ".join([
+        "codegen_func", # Requires to have bin dir in PATH
+        user,
+    ])
+    if debug:
+        print("Calling {}".format(cmd))
+    call(cmd, shell=True)
+
+def _simple_run_user(user, debug, num_runs=1):
+    cmd = " ".join([
+        "simple_runner", # Requires to have bin dir in PATH
+        user,
+        str(num_runs),
+    ])
+    if debug:
+        print("Calling {}".format(cmd))
+    call(cmd, shell=True)

--- a/tasks/compile.py
+++ b/tasks/compile.py
@@ -1,6 +1,6 @@
-from subprocess import call
-from os.path import exists, join, splitext
 from os import scandir, mkdir
+from os.path import exists, join, splitext
+from subprocess import call
 
 from invoke import task
 
@@ -54,8 +54,9 @@ def compile(ctx, user, func, clean=False, debug=False, ts=False, cp=False):
         ]
         call(" ".join(cmd), shell=True, cwd=FUNC_BUILD_DIR)
 
+
 @task
-def compile_user(ctx, user, clean=False, debug=False, cp=False, run=False):
+def compile_user(ctx, user, clean=False, debug=False, cp=False):
     target = "{}_all_funcs".format(user)
     _do_compile(target, clean, debug)
     if cp:
@@ -78,9 +79,6 @@ def compile_user(ctx, user, clean=False, debug=False, cp=False, run=False):
                 join(dest_folder, "function.wasm"),
             ]
             call(" ".join(cmd), shell=True, cwd=FUNC_BUILD_DIR)
-        if run:
-            _codegen_user(user, debug)
-            _simple_run_user(user, debug)
 
 
 def _ts_compile(func, optimize=True):
@@ -101,22 +99,3 @@ def _ts_compile(func, optimize=True):
     cmd_string = " ".join(cmd)
     print(cmd_string)
     call(cmd_string, cwd=TS_DIR, shell=True)
-
-def _codegen_user(user, debug):
-    cmd = " ".join([
-        "codegen_func", # Requires to have bin dir in PATH
-        user,
-    ])
-    if debug:
-        print("Calling {}".format(cmd))
-    call(cmd, shell=True)
-
-def _simple_run_user(user, debug, num_runs=1):
-    cmd = " ".join([
-        "simple_runner", # Requires to have bin dir in PATH
-        user,
-        str(num_runs),
-    ])
-    if debug:
-        print("Calling {}".format(cmd))
-    call(cmd, shell=True)

--- a/tasks/runner.py
+++ b/tasks/runner.py
@@ -1,0 +1,32 @@
+from subprocess import call
+
+from invoke import task
+
+from tasks.util.env import POSSIBLE_BUILD_BINS
+from tasks.util.shell import find_command
+
+
+@task
+def run_user(ctx, user, repeats=1):
+    run(ctx, user, "all", repeats=repeats)
+
+
+@task
+def run(ctx, user, function, repeats=1):
+    runner = find_command("simple_runner", POSSIBLE_BUILD_BINS)
+
+    cmd = [runner, user]
+
+    if function:
+        cmd.append(function)
+
+    if repeats:
+        cmd.append(str(repeats))
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    res = call(cmd, shell=True)
+
+    if res != 0:
+        print("Failed running command")
+        exit(1)

--- a/tasks/runner.py
+++ b/tasks/runner.py
@@ -15,10 +15,7 @@ def run_user(ctx, user, repeats=1):
 def run(ctx, user, function, repeats=1):
     runner = find_command("simple_runner", POSSIBLE_BUILD_BINS)
 
-    cmd = [runner, user]
-
-    if function:
-        cmd.append(function)
+    cmd = [runner, user, function]
 
     if repeats:
         cmd.append(str(repeats))

--- a/tasks/toolchain.py
+++ b/tasks/toolchain.py
@@ -20,11 +20,11 @@ TOOLCHAIN_INSTALL = join(FAASM_LOCAL_DIR, "toolchain")
 
 
 @task
-def codegen_for_user(ctx, user):
-    _do_codegen_for_user(user)
+def codegen_user(ctx, user):
+    _do_codegen_user(user)
 
 
-def _do_codegen_for_user(user):
+def _do_codegen_user(user):
     print("Running codegen for user {}".format(user))
 
     binary = find_codegen_func()
@@ -33,15 +33,15 @@ def _do_codegen_for_user(user):
 
 @task
 def run_local_codegen(ctx):
-    _do_codegen_for_user("demo")
-    _do_codegen_for_user("errors")
-    _do_codegen_for_user("omp")
-    _do_codegen_for_user("mpi")
+    _do_codegen_user("demo")
+    _do_codegen_user("errors")
+    _do_codegen_user("omp")
+    _do_codegen_user("mpi")
 
     # Run these in parallel
     p = Pool(3)
     users = ["python", "sgd", "tf"]
-    p.map(_do_codegen_for_user, users)
+    p.map(_do_codegen_user, users)
 
     print("Running codegen on python shared objects")
     binary = find_codegen_shared_lib()

--- a/tasks/util/codegen.py
+++ b/tasks/util/codegen.py
@@ -1,31 +1,10 @@
-from os.path import join, exists
-
-from tasks.util.env import PROJ_ROOT, HOME_DIR
-
-
-def _do_find_codegen(bin_name):
-    possible_binaries = [
-        "/faasm/build/bin/{}".format(bin_name),  # Containers
-        join(PROJ_ROOT, "build/bin/{}".format(bin_name)),  # Local builds
-        join(PROJ_ROOT, "cmake-build-debug/bin/{}".format(bin_name)),  # CLion
-        join(HOME_DIR, "faasm", "bench", "bin", bin_name), # Benchmark
-    ]
-
-    existing_binaries = [p for p in possible_binaries if exists(p)]
-    if not existing_binaries:
-        print("Could not find any codegen binaries (options = {})".format(possible_binaries))
-        exit(1)
-
-    binary = existing_binaries[0]
-    if len(existing_binaries) > 1:
-        print("WARNING: found multiple codegen binaries, taking {}".format(binary))
-
-    return binary
+from tasks.util.env import POSSIBLE_BUILD_BINS
+from tasks.util.shell import find_command
 
 
 def find_codegen_shared_lib():
-    return _do_find_codegen("codegen_shared_obj")
+    return find_command("codegen_shared_obj", POSSIBLE_BUILD_BINS)
 
 
 def find_codegen_func():
-    return _do_find_codegen("codegen_func")
+    return find_command("codegen_func", POSSIBLE_BUILD_BINS)

--- a/tasks/util/env.py
+++ b/tasks/util/env.py
@@ -56,8 +56,8 @@ LATEST_CMAKE = "/usr/local/lib/cmake-3.15/bin/cmake"
 
 POSSIBLE_BUILD_BINS = [
     "/faasm/build/bin/",  # Containers
-    join(PROJ_ROOT, "build/bin"),  # Local builds
-    join(PROJ_ROOT, "cmake-build-debug/bin"),  # CLion
+    join(PROJ_ROOT, "build", "bin"),  # Local builds
+    join(PROJ_ROOT, "cmake-build-debug", "bin"),  # CLion
     join(HOME_DIR, "faasm", "bench", "bin"),  # Benchmark
 ]
 

--- a/tasks/util/env.py
+++ b/tasks/util/env.py
@@ -54,6 +54,13 @@ FAASM_SYSROOT = join(FAASM_LOCAL_DIR, "llvm-sysroot")
 
 LATEST_CMAKE = "/usr/local/lib/cmake-3.15/bin/cmake"
 
+POSSIBLE_BUILD_BINS = [
+    "/faasm/build/bin/",  # Containers
+    join(PROJ_ROOT, "build/bin"),  # Local builds
+    join(PROJ_ROOT, "cmake-build-debug/bin"),  # CLion
+    join(HOME_DIR, "faasm", "bench", "bin"),  # Benchmark
+]
+
 
 def get_wasm_func_path(user, func_name):
     func_dir = join(WASM_DIR, user, func_name)

--- a/tasks/util/shell.py
+++ b/tasks/util/shell.py
@@ -1,0 +1,19 @@
+import shutil
+from os.path import join, exists
+
+
+def find_command(bin_name, dirs):
+    # First check on the path
+    found_cmd = shutil.which(bin_name)
+    if found_cmd:
+        return found_cmd
+
+    # If not found on the path, check in provided directories
+    possible_files = [join(d, bin_name) for d in dirs]
+    found_cmds = [b for b in possible_files if exists(b)]
+
+    found_cmd = found_cmds[0]
+    if len(found_cmds) > 1:
+        print("WARNING: found multiple candidates for {}, taking {}".format(bin_name, found_cmd))
+
+    return found_cmd


### PR DESCRIPTION
Keeps previous cmd line behaviour intact, however makes the function argument optional which results in running all codegened functions. This is useful when I want to test I didn't break some omp functions, without having to set up the tests.

### Examples

```bash
# previously possible commands, cmd line API preserved
simple_runner mpi hellompi
simple_runner mpi hellompi 5

# new commands
simple_runner mpi # runs all codegened function in the MPI Wasm folder once
simple_runner mpi 5 # same but 5 times
```