### PR TITLE
Add LLVM OpenMP project to Faasm toolchain

### DIFF
--- a/libs/cpp/CMakeLists.txt
+++ b/libs/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ project(libfaasm)
 set(CMAKE_CXX_STANDARD 17)
 
 set(PROJ_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/../../include)
-include_directories(${CMAKE_CURRENT_LIST_DIR} ${PROJ_INCLUDE})
+include_directories(${CMAKE_CURRENT_LIST_DIR} ${PROJ_INCLUDE} /usr/local/include)
 
 set(PUBLIC_HEADERS
         ${PROJ_INCLUDE}/faasm/core.h

--- a/libs/cpp/CMakeLists.txt
+++ b/libs/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ project(libfaasm)
 set(CMAKE_CXX_STANDARD 17)
 
 set(PROJ_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/../../include)
-include_directories(${CMAKE_CURRENT_LIST_DIR} ${PROJ_INCLUDE} /usr/local/include)
+include_directories(${CMAKE_CURRENT_LIST_DIR} ${PROJ_INCLUDE})
 
 set(PUBLIC_HEADERS
         ${PROJ_INCLUDE}/faasm/core.h

--- a/tests/test/lib/test_random.cpp
+++ b/tests/test/lib/test_random.cpp
@@ -13,13 +13,13 @@ using namespace faasm;
         int c = randomInteger(100, topEnd);
 
         REQUIRE(a >= 10);
-        REQUIRE(a < topEnd);
+        REQUIRE(a <= topEnd);
 
         REQUIRE(b >= 30);
-        REQUIRE(b < topEnd);
+        REQUIRE(b <= topEnd);
 
         REQUIRE(c >= 100);
-        REQUIRE(c < topEnd);
+        REQUIRE(c <= topEnd);
 
         bool allUnequal = (a != b) & (b != c);
         REQUIRE(allUnequal);

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -43,13 +43,16 @@ clean-all:
 $(BUILD_DIR)/llvm.BUILT:
 	mkdir -p $(BUILD_DIR)/llvm
 	cd $(BUILD_DIR)/llvm; cmake -G Ninja \
+		-DCMAKE_C_COMPILER=/usr/bin/clang \
+		-DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
 		-DLLVM_TARGETS_TO_BUILD=WebAssembly \
 		-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi \
 		-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=$(LLVM_PROJ_DIR)/clang \
+		-DLLVM_EXTERNAL_OPENMP_SOURCE_DIR=$(LLVM_PROJ_DIR)/openmp \
 		-DLLVM_EXTERNAL_LLD_SOURCE_DIR=$(LLVM_PROJ_DIR)/lld \
-		-DLLVM_ENABLE_PROJECTS="lld;clang" \
+		-DLLVM_ENABLE_PROJECTS="lld;clang;openmp" \
 		-DDEFAULT_SYSROOT=$(FAASM_SYSROOT) \
 		$(LLVM_PROJ_DIR)/llvm
 	ninja -v -C $(BUILD_DIR)/llvm \
@@ -78,6 +81,8 @@ $(BUILD_DIR)/libc.BUILT: $(BUILD_DIR)/llvm.BUILT
 $(BUILD_DIR)/compiler-rt.BUILT: $(BUILD_DIR)/libc.BUILT
 	mkdir -p $(BUILD_DIR)/compiler-rt
 	cd $(BUILD_DIR)/compiler-rt; cmake -G Ninja \
+		-DCMAKE_C_COMPILER=/usr/bin/clang \
+		-DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
 		-DCOMPILER_RT_BAREMETAL_BUILD=On \
@@ -131,6 +136,8 @@ $(BUILD_DIR)/libcxx.BUILT: $(BUILD_DIR)/compiler-rt.BUILT
 $(BUILD_DIR)/libcxxabi.BUILT: $(BUILD_DIR)/libcxx.BUILT
 	mkdir -p $(BUILD_DIR)/libcxxabi
 	cd $(BUILD_DIR)/libcxxabi; cmake -G Ninja \
+		-DCMAKE_C_COMPILER=/usr/bin/clang \
+		-DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
 		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
 		-DCMAKE_C_FLAGS="-I$(FAASM_SYSROOT)/include" \
 		-DCMAKE_CXX_FLAGS="-I$(FAASM_SYSROOT)/include/c++/v1" \


### PR DESCRIPTION
This fixes the OpenMP functions not compiling on the Faasm toolchain.

This PR contains two more things though:
* Uses Clang 10 (i.e. `/usr/bin/clang`) to compile the toolchain instead of a possibly old `cc`.
* I had to add the `/usr/local/include` import to be able to run `inv libs.faasm`. Possibly a bug? because this is definitely a standard path. So I don't really know...