### PR TITLE
Fix a few lock issues

### DIFF
--- a/include/redis/Redis.h
+++ b/include/redis/Redis.h
@@ -123,7 +123,7 @@ namespace redis {
         *  ------ Locking ------
         */
 
-        long acquireLock(const std::string &key, int expirySeconds);
+        std::optional<long> acquireLock(const std::string &key, int expirySeconds);
 
         void releaseLock(const std::string &key, long lockId);
 

--- a/include/redis/Redis.h
+++ b/include/redis/Redis.h
@@ -123,7 +123,7 @@ namespace redis {
         *  ------ Locking ------
         */
 
-        std::optional<long> acquireLock(const std::string &key, int expirySeconds);
+        uint32_t acquireLock(const std::string &key, int expirySeconds);
 
         void releaseLock(const std::string &key, long lockId);
 

--- a/include/state/RedisStateKeyValue.h
+++ b/include/state/RedisStateKeyValue.h
@@ -16,7 +16,7 @@ namespace state {
     private:
         const std::string joinedKey;
 
-        int lastRemoteLockId = 0;
+        uint32_t lastRemoteLockId = 0;
 
         void lockGlobal() override;
 

--- a/include/state/RedisStateKeyValue.h
+++ b/include/state/RedisStateKeyValue.h
@@ -16,8 +16,6 @@ namespace state {
     private:
         const std::string joinedKey;
 
-        std::shared_mutex localMutex;
-
         int lastRemoteLockId = 0;
 
         void lockGlobal() override;

--- a/include/state/RedisStateKeyValue.h
+++ b/include/state/RedisStateKeyValue.h
@@ -3,7 +3,7 @@
 #include "StateKeyValue.h"
 
 #include <util/clock.h>
-
+#include <util/locks.h>
 #include <redis/Redis.h>
 
 
@@ -15,6 +15,8 @@ namespace state {
         static size_t getStateSize(const std::string &userIn, const std::string keyIn);
     private:
         const std::string joinedKey;
+
+        std::shared_mutex localMutex;
 
         int lastRemoteLockId = 0;
 

--- a/include/state/StateKeyValue.h
+++ b/include/state/StateKeyValue.h
@@ -5,14 +5,16 @@
 #include <redis/Redis.h>
 
 #include <atomic>
+#include <chrono>
 #include <shared_mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
 
-#define REMOTE_LOCK_TIMEOUT_SECS 1
-#define REMOTE_LOCK_MAX_RETRIES 3
+constexpr int REMOTE_LOCK_TIMEOUT_SECS(1);
+constexpr int REMOTE_LOCK_MAX_RETRIES(10);
 
 
 namespace state {
@@ -108,7 +110,7 @@ namespace state {
 
         void initialiseStorage(bool allocate);
 
-        long waitOnRedisRemoteLock(const std::string &redisKey);
+        std::optional<long> waitOnRedisRemoteLock(const std::string &redisKey);
 
         void markDirtySegment(long offset, long len);
 

--- a/include/state/StateKeyValue.h
+++ b/include/state/StateKeyValue.h
@@ -110,7 +110,7 @@ namespace state {
 
         void initialiseStorage(bool allocate);
 
-        std::optional<long> waitOnRedisRemoteLock(const std::string &redisKey);
+        uint32_t waitOnRedisRemoteLock(const std::string &redisKey);
 
         void markDirtySegment(long offset, long len);
 

--- a/libs/faasmp/faasmp/reduction.h
+++ b/libs/faasmp/faasmp/reduction.h
@@ -46,8 +46,7 @@ public:
 
         union State val = readState(counterKey);
         val.x += increment;
-        writeState(counterKey, val
-        );
+        writeState(counterKey, val);
 
         faasmUnlockStateGlobal(counterKey);
 

--- a/src/redis/Redis.cpp
+++ b/src/redis/Redis.cpp
@@ -423,10 +423,10 @@ namespace redis {
      *  ------ Locking ------
      */
 
-    std::optional<long> Redis::acquireLock(const std::string &key, int expirySeconds) {
+    uint32_t Redis::acquireLock(const std::string &key, int expirySeconds) {
         // Implementation of single host redlock algorithm
         // https://redis.io/topics/distlock
-        long lockId = util::generateGid();
+        uint32_t lockId = util::generateGid();
 
         std::string lockKey = key + "_lock";
         bool result = this->setnxex(lockKey, lockId, expirySeconds);
@@ -434,7 +434,7 @@ namespace redis {
         if (result) {
             return lockId;
         } else {
-            return std::nullopt;
+            return 0;
         }
     }
 

--- a/src/state/InMemoryStateKeyValue.cpp
+++ b/src/state/InMemoryStateKeyValue.cpp
@@ -23,22 +23,24 @@ namespace state {
         if (masterIPBytes.empty()) {
             // Get the remote lock
 
-            if (auto masterLockId = waitOnRedisRemoteLock(masterKey)) {
-                // Check again now that we have the lock
-                masterIPBytes = redis.get(masterKey);
-                if (masterIPBytes.empty()) {
-                    // Claim the master if we've got the lock and nobody else is master
-                    redis.set(masterKey, util::stringToBytes(thisIP));
-                    masterIP = thisIP;
-                    status = InMemoryStateKeyStatus::MASTER;
-                }
+            uint32_t masterLockId = waitOnRedisRemoteLock(masterKey);
 
-                redis.releaseLock(masterKey, masterLockId.value());
-            } else {
+            if (masterLockId == 0) {
                 logger->error("Unable to acquire remote lock for {}", masterKey);
                 throw std::runtime_error("Unable to get remote lock");
+
             }
 
+            // Check again now that we have the lock
+            masterIPBytes = redis.get(masterKey);
+            if (masterIPBytes.empty()) {
+                // Claim the master if we've got the lock and nobody else is master
+                redis.set(masterKey, util::stringToBytes(thisIP));
+                masterIP = thisIP;
+                status = InMemoryStateKeyStatus::MASTER;
+            }
+
+            redis.releaseLock(masterKey, masterLockId);
         }
 
         // If we're not master after that, someone else must be

--- a/src/state/RedisStateKeyValue.cpp
+++ b/src/state/RedisStateKeyValue.cpp
@@ -28,7 +28,7 @@ namespace state {
     void RedisStateKeyValue::unlockGlobal() {
         util::FullLock lock(valueMutex);
         redis.releaseLock(joinedKey, lastRemoteLockId);
-        lastRemoteLockId = -1;
+        lastRemoteLockId = 0;
     }
 
     void RedisStateKeyValue::pullFromRemote() {

--- a/src/state/RedisStateKeyValue.cpp
+++ b/src/state/RedisStateKeyValue.cpp
@@ -19,10 +19,12 @@ namespace state {
     }
 
     void RedisStateKeyValue::lockGlobal() {
-        lastRemoteLockId = waitOnRedisRemoteLock(joinedKey);
+        util::FullLock lock(localMutex);
+        lastRemoteLockId = waitOnRedisRemoteLock(joinedKey).value_or(-1);
     }
 
     void RedisStateKeyValue::unlockGlobal() {
+        util::FullLock lock(localMutex);
         redis.releaseLock(joinedKey, lastRemoteLockId);
     }
 

--- a/src/state/RedisStateKeyValue.cpp
+++ b/src/state/RedisStateKeyValue.cpp
@@ -22,7 +22,7 @@ namespace state {
     // on the same machine. Redis is also aware of scheduling and so we could optimise this.
     void RedisStateKeyValue::lockGlobal() {
         util::FullLock lock(valueMutex);
-        lastRemoteLockId = waitOnRedisRemoteLock(joinedKey).value_or(-1);
+        lastRemoteLockId = waitOnRedisRemoteLock(joinedKey);
     }
 
     void RedisStateKeyValue::unlockGlobal() {

--- a/src/state/RedisStateKeyValue.cpp
+++ b/src/state/RedisStateKeyValue.cpp
@@ -18,14 +18,17 @@ namespace state {
         return redis.strlen(actualKey);
     }
 
+    // TODO - the remote locking here is quite primitive since we ignore the fact threads can run
+    // on the same machine. Redis is also aware of scheduling and so we could optimise this.
     void RedisStateKeyValue::lockGlobal() {
-        util::FullLock lock(localMutex);
+        util::FullLock lock(valueMutex);
         lastRemoteLockId = waitOnRedisRemoteLock(joinedKey).value_or(-1);
     }
 
     void RedisStateKeyValue::unlockGlobal() {
-        util::FullLock lock(localMutex);
+        util::FullLock lock(valueMutex);
         redis.releaseLock(joinedKey, lastRemoteLockId);
+        lastRemoteLockId = -1;
     }
 
     void RedisStateKeyValue::pullFromRemote() {

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -64,7 +64,7 @@ namespace state {
 
         // See if we have locally
         {
-            util::SharedLock sharedLock(mapMutex);
+            SharedLock sharedLock(mapMutex);
             if (kvMap.count(lookupKey) > 0) {
                 return kvMap[lookupKey];
             }

--- a/src/util/gids.cpp
+++ b/src/util/gids.cpp
@@ -9,6 +9,11 @@ namespace util {
     unsigned int generateGid() {
         std::size_t nodeHash = util::getNodeIdHash();
         unsigned int intHash = nodeHash % INT32_MAX;
-        return intHash + counter.fetch_add(1);
+        unsigned int result = intHash + counter.fetch_add(1);
+        if (result) {
+            return result;
+        } else {
+            return intHash + counter.fetch_add(1);
+        }
     }
 }

--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -353,6 +353,7 @@ namespace wasm {
         }
     }
 
+
     // Emulator API, should not be called from wasm but needs to be present for linking
     WAVM_DEFINE_INTRINSIC_FUNCTION(env, "setEmulatedMessageFromJson", I32, setEmulatedMessageFromJson, I32 msgPtr) {
         util::getLogger()->debug("S - setEmulatedMessageFromJson - {}", msgPtr);

--- a/tests/test/redis/test_redis.cpp
+++ b/tests/test/redis/test_redis.cpp
@@ -294,27 +294,27 @@ namespace tests {
 
         // Check we can acquire the lock
         auto lockId = redis.acquireLock(key, 10);
-        REQUIRE(lockId.value() > 0);
+        REQUIRE(lockId > 0);
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Check someone else can't acquire the lock
         auto lockId2 = redis.acquireLock(key, 10);
-        REQUIRE(!lockId2.has_value());
+        REQUIRE(lockId2 == 0);
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Release with an invalid lock ID and check it's still locked
-        redis.releaseLock(key, lockId.value() + 1);
+        redis.releaseLock(key, lockId + 1);
         auto lockId3 = redis.acquireLock(key, 10);
-        REQUIRE(!lockId3.has_value());
+        REQUIRE(lockId3 == 0);
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Release with valid ID and check we can re-acquire
-        redis.releaseLock(key, lockId.value());
+        redis.releaseLock(key, lockId);
         auto lockId4 = redis.acquireLock(key, 10);
-        REQUIRE(lockId4.value() > 0);
+        REQUIRE(lockId4 > 0);
         REQUIRE(lockId4 != lockId);
         REQUIRE(redis.getLong(lockKey) == lockId4);
         REQUIRE(redis.get(key) == value);

--- a/tests/test/redis/test_redis.cpp
+++ b/tests/test/redis/test_redis.cpp
@@ -293,28 +293,28 @@ namespace tests {
         redis.releaseLock(key, 1234);
 
         // Check we can acquire the lock
-        long lockId = redis.acquireLock(key, 10);
-        REQUIRE(lockId > 0);
+        auto lockId = redis.acquireLock(key, 10);
+        REQUIRE(lockId.value() > 0);
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Check someone else can't acquire the lock
-        long lockId2 = redis.acquireLock(key, 10);
-        REQUIRE(lockId2 == 0);
+        auto lockId2 = redis.acquireLock(key, 10);
+        REQUIRE(!lockId2.has_value());
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Release with an invalid lock ID and check it's still locked
-        redis.releaseLock(key, lockId + 1);
-        long lockId3 = redis.acquireLock(key, 10);
-        REQUIRE(lockId3 == 0);
+        redis.releaseLock(key, lockId.value() + 1);
+        auto lockId3 = redis.acquireLock(key, 10);
+        REQUIRE(!lockId3.has_value());
         REQUIRE(redis.getLong(lockKey) == lockId);
         REQUIRE(redis.get(key) == value);
 
         // Release with valid ID and check we can re-acquire
-        redis.releaseLock(key, lockId);
-        long lockId4 = redis.acquireLock(key, 10);
-        REQUIRE(lockId4 > 0);
+        redis.releaseLock(key, lockId.value());
+        auto lockId4 = redis.acquireLock(key, 10);
+        REQUIRE(lockId4.value() > 0);
         REQUIRE(lockId4 != lockId);
         REQUIRE(redis.getLong(lockKey) == lockId4);
         REQUIRE(redis.get(key) == value);


### PR DESCRIPTION
* Make lockId an optional because of conversion from unsigned int to
long which at worst return a negative number and therefore be treated as
a non set key..! Also it just expressed the intent more cleanly
* Add a local lock to the KV pairs, indeed when a worker has got
multiple threads running it can do boom boom
* Some cleanup